### PR TITLE
Expose focus and blur handlers

### DIFF
--- a/dist/editor.js
+++ b/dist/editor.js
@@ -46,7 +46,9 @@ module.exports = React.createClass({
     return React.createElement(this.props.tag, {
       className: this.props.className,
       contentEditable: true,
-      dangerouslySetInnerHTML: { __html: this.state.text }
+      dangerouslySetInnerHTML: { __html: this.state.text },
+      onFocus: this.props.onFocus,
+      onBlur: this.props.onBlur
     });
   },
 

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -42,7 +42,9 @@ module.exports = React.createClass({
     return React.createElement(this.props.tag, {
       className: this.props.className,
       contentEditable: true,
-      dangerouslySetInnerHTML: {__html: this.state.text}
+      dangerouslySetInnerHTML: {__html: this.state.text},
+      onFocus: this.props.onFocus,
+      onBlur: this.props.onBlur
     });
   },
 


### PR DESCRIPTION
This is useful if there is an action you'd like to take when the `contenteditable` element is being used.
