### PR TITLE
Compare against dom.innerHTML

### DIFF
--- a/dist/editor.js
+++ b/dist/editor.js
@@ -25,7 +25,6 @@ module.exports = React.createClass({
     var dom = ReactDOM.findDOMNode(this);
     this.medium = new MediumEditor(dom, this.props.options);
     this.medium.subscribe('editableInput', function (e) {
-      _this._updated = true;
       _this.change(dom.innerHTML);
     });
   },
@@ -33,11 +32,10 @@ module.exports = React.createClass({
     this.medium.destroy();
   },
   componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
-    if (nextProps.text !== this.state.text && !this._updated) {
+    var dom = ReactDOM.findDOMNode(this);
+    if (nextProps.text !== dom.innerHTML) {
       this.setState({ text: nextProps.text });
     }
-
-    if (this._updated) this._updated = false;
   },
   render: function render() {
     var tag = this.props.tag;


### PR DESCRIPTION
Currently the DOM will not update if a changed `props.text` is supplied after `onChange` is called. Comparing to `dom.innerHTML` fixes this since it will always reflect the latest change whereas `state.text` is one change behind.

The scenario is where a user presses a key and the application needs to update the HTML based off that change. Imagine replacing emoji shorthand, `:neckbeard:`, with the actual emoji :neckbeard:. This functionality could be written as a medium-editor plugin but I think it's reasonable to expect applications to update HTML as well.

Here is the flow I'm describing. The last step does not happen with the current implementation:

```
user types :neckbeard:
  => medium-editor emits change
  => application replaces :neckbeard: with emoji
  => application passes new HTML to MediumEditor component
  => component needs to update state.text
```
