### PR TITLE
Expose medium editor so that extensions could be added

### DIFF
--- a/dist/editor.js
+++ b/dist/editor.js
@@ -54,3 +54,5 @@ module.exports = React.createClass({
     if (this.props.onChange) this.props.onChange(text, this.medium);
   }
 });
+
+module.exports.MediumEditor = MediumEditor;

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -56,3 +56,5 @@ module.exports = React.createClass({
     if(this.props.onChange) this.props.onChange(text, this.medium);
   }
 });
+
+module.exports.MediumEditor = MediumEditor


### PR DESCRIPTION
I'm not sure if it's possible to add extensions without having access to the same MediumEditor instance used by react-medium-editor.
