### PR TITLE
Fix restoring cursor when props.text

### DIFF
--- a/lib/editor.js
+++ b/lib/editor.js
@@ -32,6 +32,10 @@ module.exports = React.createClass({
     });
   },
 
+  componentDidUpdate() {
+    this.medium.restoreSelection();  
+  },
+  
   componentWillUnmount() {
     this.medium.destroy();
   },
@@ -52,6 +56,10 @@ module.exports = React.createClass({
       contentEditable: true,
       dangerouslySetInnerHTML: {__html: this.state.text}
     });
+    
+    if(this.medium) {
+      this.medium.saveSelection();
+    }
 
     return React.createElement(tag, props);
   },


### PR DESCRIPTION
@wangzuo Please check the app before merging this commit. I am pretty sure it will work, but I haven't checked it. I have created an ES6 fork of this project (https://github.com/channikhabra/react-medium-editor-es6/) and am using that. Creating this PR to save you some time with #18
