### PR TITLE
Remove contentEditable prop from the editor element

### DIFF
--- a/dist/editor.js
+++ b/dist/editor.js
@@ -48,7 +48,6 @@ module.exports = React.createClass({
     var props = blacklist(this.props, 'tag', 'contentEditable', 'dangerouslySetInnerHTML');
 
     assign(props, {
-      contentEditable: true,
       dangerouslySetInnerHTML: { __html: this.state.text }
     });
 

--- a/example/app.js
+++ b/example/app.js
@@ -28,10 +28,19 @@ module.exports = React.createClass({
           onChange={this.handleChange}
           options={{toolbar: {buttons: ['bold', 'italic', 'underline']}}}
         />
+
         <h3>Editor #2</h3>
         <Editor
           text={this.state.text}
           onChange={this.handleChange}
+        />
+
+        <h3>Editor #3 (editing disabled)</h3>
+        <p>Useful for using the toolbar with customized buttons/actions</p>
+        <Editor
+          style={{ outline: 'dotted 1px', padding: 10 }}
+          text={this.state.text}
+          options={{disableEditing: true, toolbar: false }}
         />
       </div>
     );

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -49,7 +49,6 @@ module.exports = React.createClass({
     var props = blacklist(this.props, 'tag', 'contentEditable', 'dangerouslySetInnerHTML');
 
     assign(props, {
-      contentEditable: true,
       dangerouslySetInnerHTML: {__html: this.state.text}
     });
 


### PR DESCRIPTION
MediumEditor sets the `contenteditable` attribute itself based on whether the presence of the `disableEditing` in the `options` object. Settings `contentEditable: true` on the HTML element prevents the editor from controlling this behaviour.
