### PR TITLE
Remove overhead dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-	"presets": ["es2015", "react"]
+	"presets": ["es2015", "react", "stage-0"]
 }

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -1,7 +1,6 @@
-var assign = require('object-assign');
-var blacklist = require('blacklist');
 var React = require('react');
 var ReactDOM = require('react-dom');
+import { excludeProps } from "./utils";
 
 if(typeof document !== 'undefined') {
   var MediumEditor = require('medium-editor');
@@ -46,12 +45,13 @@ module.exports = React.createClass({
 
   render() {
     var tag = this.props.tag;
-    var props = blacklist(this.props, 'tag', 'contentEditable', 'dangerouslySetInnerHTML');
+    var props = excludeProps(this.props, 'tag', 'contentEditable', 'dangerouslySetInnerHTML');
 
-    assign(props, {
-      contentEditable: true,
-      dangerouslySetInnerHTML: {__html: this.state.text}
-    });
+    props = {
+        ...props,
+        contentEditable: true,
+        dangerouslySetInnerHTML: {__html: this.state.text}
+    };
 
     return React.createElement(tag, props);
   },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,16 @@
+export const excludeProps = obj => {
+    let copy = {};
+    let filter = {};
+
+    for (let i = 1; i < arguments.length; i++) {
+        filter[arguments[i]] = true;
+    }
+
+    for (let key in obj) {
+        if (filter[key]) continue;
+
+        copy[key] = obj[key];
+    }
+
+    return copy;
+}

--- a/package.json
+++ b/package.json
@@ -33,15 +33,14 @@
     "react-dom": "^0.14.0"
   },
   "dependencies": {
-    "blacklist": "^1.1.2",
-    "medium-editor": "^5.10.0",
-    "object-assign": "^4.0.1"
+    "medium-editor": "^5.10.0"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",
     "babel-loader": "^6.1.0",
     "babel-preset-es2015": "^6.1.2",
     "babel-preset-react": "^6.1.2",
+    "babel-preset-stage-0": "^6.5.0",
     "css-loader": "^0.22.0",
     "github-pages-deploy": "0.0.3",
     "static-site-generator-webpack-plugin": "^2.0.1",


### PR DESCRIPTION
Hello!
You use babel 6, so it seems like no need to use package `object-assign`, better use ES6.
Also in my opinion there is no need to pull dependency `blacklist` for 10 lines of code so I just replaced it with helper function.
