### PR TITLE
Removed findomnode which will be deprecated.

### DIFF
--- a/lib/editor.js
+++ b/lib/editor.js
@@ -1,7 +1,6 @@
 import assign from 'object-assign';
 import blacklist from 'blacklist';
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 if (typeof document !== 'undefined') {
   var MediumEditor = require('medium-editor');
@@ -21,12 +20,10 @@ export default class ReactMediumEditor extends React.Component {
   }
 
   componentDidMount() {
-    const dom = ReactDOM.findDOMNode(this);
-
-    this.medium = new MediumEditor(dom, this.props.options);
+    this.medium = new MediumEditor(this.dom, this.props.options);
     this.medium.subscribe('editableInput', (e) => {
       this._updated = true;
-      this.change(dom.innerHTML);
+      this.change(this.dom.innerHTML);
     });
   }
 
@@ -49,6 +46,7 @@ export default class ReactMediumEditor extends React.Component {
   render() {
     const tag = this.props.tag;
     const props = blacklist(this.props, 'options', 'text', 'tag', 'contentEditable', 'dangerouslySetInnerHTML');
+    props.ref = node => this.dom = node
 
     assign(props, {
       dangerouslySetInnerHTML: { __html: this.state.text }


### PR DESCRIPTION
Method `findDOMNode` has been deprecated in later versions of react [see here](https://github.com/yannickcr/eslint-plugin-react/issues/678). This PR suggests a way to do exactly the same using refs in order not to get an error when executing and for later compatibility.

Made with ❤️ 
Thanks!

PD: Any comment is more than appreciated.